### PR TITLE
Dispatcher changes to have on/once accept listeners as the normal signature

### DIFF
--- a/src/Application.js
+++ b/src/Application.js
@@ -107,10 +107,11 @@ export default class Application extends Dispatcher {
    * @return {Promise}
    */
   init() {
-    return this._loadPlugins().then(this.boot.bind(this))
-    if (!this.config.script && this.config.NODE_ENV != 'production') {
-      this.appWatcher = new Watcher(this, this._getWatchPaths(), 'change', this._getAppIgnorePaths())
-    }
+    return this._loadPlugins().then(this.boot.bind(this)).then(() => {
+      if (!this.config.script && this.config.NODE_ENV != 'production') {
+        this.appWatcher = new Watcher(this, this._getWatchPaths(), 'change', this._getAppIgnorePaths())
+      }
+    });
   }
 
   /**

--- a/src/Dispatcher.js
+++ b/src/Dispatcher.js
@@ -38,12 +38,40 @@ export default class Dispatcher extends EventEmitter {
   /**
    * Bind to an event
    * @param  {string} event The name of the event to bind to
+   * @param  {callable} listener The handler for the event 
+   */
+  on (event, listener) {
+    if (listener === undefined) {
+      listener = () => {};
+    }
+    return super.on.apply(this, [event, listener]);
+  }
+
+  /**
+   * Bind to an event once
+   * @param  {string} event The name of the event to bind to 
+   * @param  {callable} listener (optional) The handler for the event
    * @return {Promise}       Returns a promise that resolves when the event fires
    */
-  on (event) {
-    let superOn = super.on
+  once (event, listener) {
+    let superOnce = super.once
+    if (listener === undefined) {
+      listener = () => {};
+    }
+
     return new Promise((resolve, reject) => {
-      superOn.apply(this, [event, resolve])
+      var fired = false;
+
+      var g = (...args) => {
+        this.removeListener(event, g);
+        
+        if (!fired) {
+          fired = true;
+          resolve(listener.apply(this, args));
+        }
+      }
+      g.listener = listener;
+      this.on.apply(this, [event, g]);
     })
   }
 

--- a/src/Dispatcher.js
+++ b/src/Dispatcher.js
@@ -67,7 +67,9 @@ export default class Dispatcher extends EventEmitter {
         
         if (!fired) {
           fired = true;
-          resolve(listener.apply(this, args));
+          var result = listener.apply(this, args);
+          resolve(result);
+          return result;
         }
       }
       g.listener = listener;

--- a/src/Module.js
+++ b/src/Module.js
@@ -15,7 +15,7 @@ export default class Module extends Dispatcher {
     this._name = name
     this._app = app
     this._awaits = {}
-    this._appLoaded = app.on('load.after')
+    this._appLoaded = app.once('load.after')
   }
 
   gather(name) {

--- a/src/Watcher.js
+++ b/src/Watcher.js
@@ -29,7 +29,7 @@ class Watcher {
       }
     ) 
 
-    app.on('change').then((path) => {
+    app.on('change', (path) => {
       this.watch.close();
       var start = moment()
       app.restart().then(() => {

--- a/test/lib/Application.js
+++ b/test/lib/Application.js
@@ -66,6 +66,32 @@ describe("Application", () => {
       app.emit('test').with(1);
       app.emit('test').with(2);
     })
+    it("once should wait for events that return a promise", (done) => {
+      var waited = false;
+      app.once('launch').then(() => {
+        waited.should.be.true();
+        done();
+      });
+      var promise = new Promise((resolve, reject) => {
+        setTimeout(() => { waited = true; resolve(); }, 500);
+      });
+      app.once('init', () => { return promise });
+      app.start();
+      
+    });
+    it("on should wait for events that return a promise", (done) => {
+      var waited = false;
+      app.once('launch').then(() => {
+        waited.should.be.true();
+        done();
+      });
+      var promise = new Promise((resolve, reject) => {
+        setTimeout(() => { waited = true; resolve(); }, 500);
+      });
+      app.on('init', () => { return promise });
+      app.start();
+      
+    });
   })
 
   describe("Boot Stages", () => {

--- a/test/lib/Application.js
+++ b/test/lib/Application.js
@@ -112,4 +112,16 @@ describe("Application", () => {
       app.start();
     });
   })
+  describe("Get Module", () => {
+    beforeEach(() => {
+      app = new Application()
+    })
+
+    it("should return a Module", (done) => {
+      app.get('something').on.should.be.Function()
+      app.get('something').gather.should.be.Function()
+      app.get('something').send.should.be.Function()
+      done();
+    });
+  });
 })


### PR DESCRIPTION
once() still returns a promise for then, but on() can't for multiply-called events.