### PR TITLE
Replace and Default with consistent implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # @nxus/core
 
+## \_
+
 [![Build Status](https://travis-ci.org/nxus/core.svg?branch=master)](https://travis-ci.org/nxus/core)
 
 The Nxus Core package includes the basic Application framework for building a Nxus app.
@@ -349,7 +351,69 @@ Modules are accessed through the Application.get() method
 
 ```javascript
 let router = app.get('router')
+
+Producer modules should register themselves with the use() method, and define gather() and respond() handlers:
 ```
+
+```javascript
+app.get('router').use(this).gather('route')
+```
+
+```javascript
+app.get('templater').use(this).respond('template')
+
+Consumer modules should get the module they need to use and call provide or request
+```
+
+```javascript
+app.get('router').provide('route', ...)
+```
+
+```javascript
+app.get('templater').request('render', ...)
+
+Modules proxy event names as methods to provide/request, so these are synomymous with above:
+```
+
+```javascript
+app.get('router').route(...)
+```
+
+```javascript
+app.get('templater').render(...)
+
+Default implementations should be indicated by using default() to occur before provide()
+Overriding another implementation can use replace() to occur after provide()
+```
+
+```javascript
+app.get('router').default('route', GET', '/', ...)
+```
+
+```javascript
+app.get('router').replace('route', GET', '/', ...)
+
+Provide, default, and replace all return a proxy object if called with no arguments, so these are synonymous with above:
+```
+
+```javascript
+app.get('router').default().route('GET', '/', ...)
+```
+
+```javascript
+app.get('router').replace().route('GET', '/', ...)
+```
+
+### default
+
+Provide default arguments to a delayed gather() call, before other provides
+
+**Parameters**
+
+-   `name` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The name of the gather event
+-   `args` **...Any** Arguments to provide to the gather event
+
+Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)** Resolves when the event is eventually handled
 
 ### gather
 
@@ -371,20 +435,9 @@ Provide arguments to a delayed gather() call.
 
 Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)** Resolves when the event is eventually handled
 
-### provideAfter
+### replace
 
-Provide arguments to a delayed gather() call, after the main provide() calls.
-
-**Parameters**
-
--   `name` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The name of the gather event
--   `args` **...Any** Arguments to provide to the gather event
-
-Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)** Resolves when the event is eventually handled
-
-### provideBefore
-
-Provide arguments to a delayed gather() call, but do it before the other provide() calls.
+Provide a replacement for a delayed gather() call (after others are provided)
 
 **Parameters**
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nxus/core",
   "main": "lib/index.js",
-  "version": "2.3.13",
+  "version": "2.3.14",
   "description": "A framework for building light-weight, event-driven data processing apps.",
   "scripts": {
     "test": "npm run compile && NODE_ENV=test mocha --compilers js:babel/register -R spec test/lib/*",

--- a/test/lib/Module.js
+++ b/test/lib/Module.js
@@ -49,6 +49,8 @@ describe("Module", () => {
       inst.on.should.be.Function();
       inst.emit.should.be.Function();
       inst.provide.should.be.Function();
+      inst.default.should.be.Function();
+      inst.replace.should.be.Function();
       inst.gather.should.be.Function();
       inst.request.should.be.Function();
       inst.respond.should.be.Function();
@@ -107,8 +109,61 @@ describe("Module", () => {
         done();
       });
     })
+    it("should return proxy for argument-less", (done) => {
+      module.gather('testGather3', (arg) => {
+        arg.should.equal(1);
+        return "one";
+      });
+      module.provide().testGather3(1).then((result) => {
+        result.should.equal("one");
+        done()
+      });
+    })
   });
 
+  describe("Default and Replace", () => {
+    before(() => {
+      module = new Module(app, 'test')
+    })
+    it("should have methods", () => {
+      module.original.should.be.Function();
+      module.replace.should.be.Function();
+    })
+    it("should gather after load", (done) => {
+      var waited = false;
+      var original = false;
+      module.gather('testDefault', (arg) => {
+        if (arg == 1) {
+          waited.should.be.false
+          original = arg
+        } else {
+          original.should.equal(1)
+          waited = true;
+          done();
+        }
+      });
+      module.replace('testDefault', 2)
+      module.default('testDefault', 1)
+      app.on('load', () => {
+        waited.should.be.false;
+      })
+      app.emit('load');
+    })
+    it("should return proxy for argument-less", (done) => {
+      module.gather('testDefault2', (arg) => {
+        arg.should.equal(1);
+        return "one";
+      });
+      module.default().testDefault2(1).then((result) => {
+        result.should.equal("one");
+      });
+      module.replace().testDefault2(1).then((result) => {
+        result.should.equal("one");
+        done()
+      });
+    })
+  });
+  
   describe("Request and Respond", () => {
     it("should have methods", () => {
       module.request.should.be.Function();


### PR DESCRIPTION
 - Rename (with alias to old names) `provideBefore` -> `default` and `provideAfter` -> `replace`
 - Fix issue with provideBefore triggering on after-init rather than before-load
 - Provide/Replace/Default all return a proxy object if called with no arguments.