### PR TITLE
Capture event-before arg and pass to event-after handler

### DIFF
--- a/src/Dispatcher.js
+++ b/src/Dispatcher.js
@@ -116,23 +116,13 @@ export default class Dispatcher extends EventEmitter {
       .then((newArgs) => {
         return Promise.all(super.listeners(event).map((handler) => {
           let ret = handler(...newArgs)
-          return Promise.resolve(ret)
+          return [Promise.resolve(ret), newArgs]
         }))
-      }).then(this._handleArrayReturn.bind(this))
+      })
       .then((results) => {
-        if(!results) results = [] //hack to get the reducer to work when results are undefined and after listeners.length == 1
+      .spread((results, newArgs) => {
+        if (results) results.arguments = newArgs
         return Promise.reduce(super.listeners(event+".after"), waterfaller, results)
       }).then(this._handleArrayReturn.bind(this));
-  }
-
-  _handleArrayReturn (results) {
-    if(_.isArray(results)) {
-      results = _.compact(results)
-      if(results.length < 1) return undefined
-      else if (results.length == 1) return results[0]
-      else return results
-    } else {
-      return results
-    }
   }
 } 

--- a/src/Dispatcher.js
+++ b/src/Dispatcher.js
@@ -106,23 +106,38 @@ export default class Dispatcher extends EventEmitter {
    */
   emit (event, ...args) {
 
-    let waterfaller = (prev, curr) => {
-      // Need to resolve internally so that we can allow observing-only handlers
-      //  that don't return anything, even from their promise.
-      return Promise.resolve(curr(prev)).then((_args) => { return _args || prev });
+    let waterfaller = (newArgs) => {
+      return (prev, curr) => {
+        // Need to resolve internally so that we can allow observing-only handlers
+        //  that don't return anything, even from their promise.
+        return Promise.resolve(curr(prev, newArgs)).then((_args) => { return _args || prev });
+      }      
     }
 
-    return Promise.reduce(super.listeners(event+".before"), waterfaller, args)
+    return Promise.reduce(super.listeners(event+".before"), waterfaller(), args)
       .then((newArgs) => {
         return Promise.all(super.listeners(event).map((handler) => {
           let ret = handler(...newArgs)
-          return [Promise.resolve(ret), newArgs]
-        }))
+          return Promise.resolve(ret)
+        })).then((results) => {
+          return [results, newArgs]
+        })
       })
-      .then((results) => {
       .spread((results, newArgs) => {
-        if (results) results.arguments = newArgs
-        return Promise.reduce(super.listeners(event+".after"), waterfaller, results)
-      }).then(this._handleArrayReturn.bind(this));
+        results = this._squashArrayResults(results)
+        if (!results) {
+          results = []
+        }
+        return this._squashArrayResults(Promise.reduce(super.listeners(event+".after"), waterfaller(newArgs), results));
+      });
+  }
+
+  _squashArrayResults(results) {
+    if(_.isArray(results)) {
+      results = _.compact(results)
+      if(results.length < 1) return undefined
+      else if (results.length == 1) return results[0]
+    }
+    return results
   }
 } 

--- a/src/Module.js
+++ b/src/Module.js
@@ -80,6 +80,7 @@ class Module extends Dispatcher {
   }
 
   _provide(myself, when, name, ...args) {
+    console.log("myself", name)
     if (name === undefined) {
       return ProxyMethods(() => { return this}, myself)()
     }
@@ -142,8 +143,14 @@ class Module extends Dispatcher {
    */  
   gather(name, handler) {
     this.after(name, (results) => {
-      if (results.length == 1) {
-        return results[0]
+      if(_.isArray(results)) {
+        results = _.compact(results)
+        if(results.length < 1) {
+          return undefined
+        }
+        if (results.length == 1) {
+          return results[0]
+        }
       }
       return results;
     });

--- a/src/Module.js
+++ b/src/Module.js
@@ -6,6 +6,8 @@
 
 'use strict';
 
+import _ from 'underscore'
+
 import Dispatcher from './Dispatcher'
 
 import ProxyMethods from './ProxyMethods'
@@ -80,7 +82,6 @@ class Module extends Dispatcher {
   }
 
   _provide(myself, when, name, ...args) {
-    console.log("myself", name)
     if (name === undefined) {
       return ProxyMethods(() => { return this}, myself)()
     }
@@ -142,18 +143,6 @@ class Module extends Dispatcher {
    * @param  {callable} handler The handler for each provided value
    */  
   gather(name, handler) {
-    this.after(name, (results) => {
-      if(_.isArray(results)) {
-        results = _.compact(results)
-        if(results.length < 1) {
-          return undefined
-        }
-        if (results.length == 1) {
-          return results[0]
-        }
-      }
-      return results;
-    });
     this.on(name, handler);
     return this;
   }


### PR DESCRIPTION
Enables the render-in-template functionality where we need to pass details between before and after `renderer.render`