### PR TITLE
Warn for missing/misnamed modules and events

### DIFF
--- a/src/Application.js
+++ b/src/Application.js
@@ -153,6 +153,11 @@ export default class Application extends Dispatcher {
     this.after('launch', () => {
       this._writeConfig()
     })
+
+    this.registeredModules = {}
+    this.on('registeredModule', (name) => {
+      this.registeredModules[name] = true
+    })
   }
 
   /**

--- a/src/Module.js
+++ b/src/Module.js
@@ -51,9 +51,12 @@ class Module extends Dispatcher {
     this._name = name;
     this.loaded = false
     app.on('stop', this.removeAllListeners.bind(this));
-    this._app.on('load.before', () => {
+    app.on('load.before', () => {
       this.loaded = true
     })
+    this._requestedEvents = {}
+    this._registeredEvents = {}
+    app.after('launch', this._checkMissingEvents.bind(this))
   }
 
   /**
@@ -81,10 +84,18 @@ class Module extends Dispatcher {
     return instance
   }
 
+  _checkMissingEvents() {
+    let diff = _.difference(_.keys(this._requestedEvents), _.keys(this._registeredEvents))
+    if (diff.length) {
+      this._app.log.warn("Module", this._name, "called with events:", diff.join(' '), "but only knows of:", _.keys(this._registeredEvents).join(' '))
+    }
+  }
+
   _provide(myself, when, name, ...args) {
     if (name === undefined) {
       return ProxyMethods(() => { return this}, myself)()
     }
+    this._requestedEvents[name] = true
     if(!this.loaded)
       return this._app[when]('load').then(() => {
         return this.emit(name, ...args);
@@ -143,6 +154,7 @@ class Module extends Dispatcher {
    * @param  {callable} handler The handler for each provided value
    */  
   gather(name, handler) {
+    this._registeredEvents[name] = true
     this.on(name, handler);
     return this;
   }

--- a/src/Module.js
+++ b/src/Module.js
@@ -85,9 +85,15 @@ class Module extends Dispatcher {
   }
 
   _checkMissingEvents() {
-    let diff = _.difference(_.keys(this._requestedEvents), _.keys(this._registeredEvents))
+    let registered = _.keys(this._registeredEvents)
+    if (registered.length == 0) {
+      this._app.log.warn("Application.get called with", this._name, "but only knows of:", _.keys(this._app.registeredModules).join(' '))
+      return
+    }
+    
+    let diff = _.difference(_.keys(this._requestedEvents), registered)
     if (diff.length) {
-      this._app.log.warn("Module", this._name, "called with events:", diff.join(' '), "but only knows of:", _.keys(this._registeredEvents).join(' '))
+      this._app.log.warn("Module", this._name, "called with events:", diff.join(' '), "but only knows of:", registered.join(' '))
     }
   }
 
@@ -154,6 +160,9 @@ class Module extends Dispatcher {
    * @param  {callable} handler The handler for each provided value
    */  
   gather(name, handler) {
+    if (_.isEmpty(this._registeredEvents)) {
+      this._app.emit('registeredModule', this._name)
+    }
     this._registeredEvents[name] = true
     this.on(name, handler);
     return this;

--- a/test/lib/Application.js
+++ b/test/lib/Application.js
@@ -6,11 +6,10 @@
 
 'use strict';
 
-var Application = require('../../lib/').Application
+import {Application} from '../../lib'
 
-var Promise = require('bluebird')
+import Promise from 'bluebird'
 
-var should = require('should')
 
 describe("Application", () => {
   var app;

--- a/test/lib/Module.js
+++ b/test/lib/Module.js
@@ -196,17 +196,25 @@ describe("Module", () => {
 
   describe("Warns for unregistered events", () => {
     let m, a
-    before((done) => {
+    beforeEach((done) => {
       a = new TestApp()
       m = new Module(a, 'test')
       done()
     })
-    it("warns after launch", (done) => {
+    it("warns for events after launch", (done) => {
       m.respond('someSuchEvent', () => {})
       m.request('noSuchEvent', 1)
       a.launch().then(() => {
         a.log.warn.called.should.be.true()
         a.log.warn.calledWith('Module', 'test', 'called with events:', 'noSuchEvent').should.be.true()
+        done()
+      })
+    })
+    it("warns for module after launch", (done) => {
+      m.request('noSuchEvent', 1)
+      a.launch().then(() => {
+        a.log.warn.called.should.be.true()
+        a.log.warn.calledWith('Application.get called with', 'test', 'but only knows of:').should.be.true()
         done()
       })
     })

--- a/test/lib/Module.js
+++ b/test/lib/Module.js
@@ -194,4 +194,22 @@ describe("Module", () => {
     })
   });
 
+  describe("Warns for unregistered events", () => {
+    let m, a
+    before((done) => {
+      a = new TestApp()
+      m = new Module(a, 'test')
+      done()
+    })
+    it("warns after launch", (done) => {
+      m.respond('someSuchEvent', () => {})
+      m.request('noSuchEvent', 1)
+      a.launch().then(() => {
+        a.log.warn.called.should.be.true()
+        a.log.warn.calledWith('Module', 'test', 'called with events:', 'noSuchEvent').should.be.true()
+        done()
+      })
+    })
+  })
+
 });  

--- a/test/lib/TestApp.js
+++ b/test/lib/TestApp.js
@@ -7,25 +7,25 @@ describe("TestApp", () => {
   
   it("Get", () => {
     app.get('module')
-    app.get.calledWith('module').should.be.true
+    app.get.calledWith('module').should.be.true()
   });
 
   it("Provide", () => {
     var ret = app.get('module').provide('event', 'val')
-    app.get().provide.calledWith('event', 'val').should.be.true
+    app.get().provide.calledWith('event', 'val').should.be.true()
     ret.then.should.be.Function();
   });
 
   it("Use", () => {
     app.get('module').use({'event': () => {}}).gather('event')
-    app.get().gather.calledWith('module').should.be.true
+    app.get().gather.calledWith('event').should.be.true()
   });
 
   it("Default and Replace", () => {
     app.get('module').default().something('here')
-    app.get().default.calledWith('something').should.be.true
+    app.get().provide.calledWith('something').should.be.true()
     app.get('module').replace().something('here')
-    app.get().replace.calledWith('something').should.be.true
+    app.get().provide.calledWith('something').should.be.true()
   });
   
 })


### PR DESCRIPTION
Resolves #24 

Uses the registering of an event handler (`respond` or `gather`) to determine if a module or event is real, so both are handled in checking for events that were requested but cannot be fulfilled.

<img width="624" alt="warn_events" src="https://cloud.githubusercontent.com/assets/539208/14295287/0c5d1196-fb43-11e5-8423-94618198c267.png">
