### PR TITLE
Restart should only remove listeners from local modules

### DIFF
--- a/src/ModuleProxy.js
+++ b/src/ModuleProxy.js
@@ -55,17 +55,26 @@ class ModuleProxy extends Dispatcher {
     this._app = app;
     this._name = name;
     this.loaded = false
-    app.on('stop', () => {
-      this.removeAllListeners()
-      this.loaded = false
-    })
-    app.on('load.before', () => {
-      this.loaded = true
-    })
+    app.on('stop', ::this._onStop)
+    app.on('load.before', ::this._beforeLoad)
     this._requestedEvents = {}
     this._registeredEvents = {}
     app.after('launch', this._checkMissingEvents.bind(this))
     this._instance = null
+  }
+
+  _onStop() {
+    this.removeAllListeners()
+    this.loaded = false
+  }
+
+  _beforeLoad() {
+    this.loaded = true
+  }
+
+  deregister() {
+    this._app.removeListener('stop', ::this._onStop)
+    this._app.removeListener('load.before', ::this._beforeLoad)
   }
 
   /**

--- a/src/NxusModule.js
+++ b/src/NxusModule.js
@@ -25,7 +25,8 @@ class NxusModule {
 
   constructor(app) {
     this.__name = this.constructor._moduleName()
-    application.get(this.__name).use(this)
+    this.__proxy = application.get(this.__name)
+    this.__proxy.use(this)
 
     this.log = Logger(this.__name)
 
@@ -61,6 +62,10 @@ class NxusModule {
 
   static getProxy() {
     return application.get(this._moduleName())
+  }
+
+  deregister() {
+    this.__proxy.deregister()
   }
 
 }

--- a/src/Watcher.js
+++ b/src/Watcher.js
@@ -37,7 +37,6 @@ export default class Watcher {
     ) 
 
     app.on('change', (path) => {
-      this.watch.close();
       var start = moment()
       if(app._currentStage != app._bootEvents[app._bootEvents.length - 1]) return
       app.restart().then(() => {


### PR DESCRIPTION
This requires some coorperation from the modules, they need to remove their own listeners that have been added to `application` when `NxusModule.deregister()` is called. Only relevant today for app-local modules (since that's what we restart), worth adding a helper to NxusModule for registering (and automatically deregistering) app boot cycle events if this works.