### PR TITLE
Code cleanup, promises and packaging

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,6 @@
+.babelrc
+.gitignore
+.npmignore
+.travis.yml
 src
-docs
+test

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "preversion": "npm test",
     "postversion": "npm run build-docs && git push && git push --tags",
     "test": "npm run compile && NODE_ENV=test nxus_myconfig=test mocha --compilers js:babel-core/register -R spec test/lib/* --config=./test/testApp/.nxusrc",
-    "compile": "rm -rf lib/; babel src --out-dir lib --ignore src/test && babel test/support/ --out-dir lib/test/support/",
+    "compile": "rm -rf lib/; babel src --out-dir lib && babel test/support/ --out-dir lib/test/support/",
     "prepublish": "npm run compile",
     "postpublish": "npm run build-docs && npm run publish-docs",
     "build-docs": "export NAME=`npm view . name`; export VERSION=`npm view . version`; documentation readme ./src/index.js --name $NAME --project-version $VERSION --readme-file ./README.md -s $NAME",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "preversion": "npm test",
     "postversion": "npm run build-docs && git push && git push --tags",
     "test": "npm run compile && NODE_ENV=test nxus_myconfig=test mocha --compilers js:babel-core/register -R spec test/lib/* --config=./test/testApp/.nxusrc",
-    "compile": "rm -r lib/; babel src --out-dir lib --ignore src/test && babel test/support/ --out-dir lib/test/support/",
+    "compile": "rm -rf lib/; babel src --out-dir lib --ignore src/test && babel test/support/ --out-dir lib/test/support/",
     "prepublish": "npm run compile",
     "postpublish": "npm run build-docs && npm run publish-docs",
     "build-docs": "export NAME=`npm view . name`; export VERSION=`npm view . version`; documentation readme ./src/index.js --name $NAME --project-version $VERSION --readme-file ./README.md -s $NAME",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "preversion": "npm test",
     "postversion": "npm run build-docs && git push && git push --tags",
     "test": "npm run compile && NODE_ENV=test nxus_myconfig=test mocha --compilers js:babel-core/register -R spec test/lib/* --config=./test/testApp/.nxusrc",
-    "compile": "babel src --out-dir lib && babel test/support/ --out-dir lib/test/support/",
+    "compile": "rm -r lib/; babel src --out-dir lib --ignore src/test && babel test/support/ --out-dir lib/test/support/",
     "prepublish": "npm run compile",
     "postpublish": "npm run build-docs && npm run publish-docs",
     "build-docs": "export NAME=`npm view . name`; export VERSION=`npm view . version`; documentation readme ./src/index.js --name $NAME --project-version $VERSION --readme-file ./README.md -s $NAME",

--- a/src/Application.js
+++ b/src/Application.js
@@ -1,15 +1,13 @@
-/* 
+/*
 * @Author: mjreich
 * @Date:   2015-05-18 17:03:15
 * @Last Modified 2016-09-13
 * @Last Modified time: 2016-09-13 15:08:51
 */
 
+import Promise from 'bluebird'
 import _ from 'underscore'
-import util from 'util'
 import fs from 'fs'
-import domain from 'domain'
-import path from 'path'
 
 import Dispatcher from './Dispatcher'
 import ModuleProxy from './ModuleProxy'
@@ -42,11 +40,11 @@ var startupBanner = " _______ _______ __    _ __   __ __   __ _______ __  \n"+
     "|_______|_______|_|  |__|__| |__|_______|_______|__| \n"
 
 /**
- * 
+ *
  * The Core Application class.
  *
  * ### Configuration Options
- * 
+ *
  * Available options are:
  *
  * | Name | Description |
@@ -58,17 +56,17 @@ var startupBanner = " _______ _______ __    _ __   __ __   __ _______ __  \n"+
  * | debug | Boolean to display debug messages, including startup banner |
  * | script | Boolean to indicate the application is a CLI script, silences all logging/output messages except for explicit console.log calls |
  * | silent | Don't show any console output. Useful for CLI scripts. |
- * 
+ *
  * @param {Object} opts the configuration options
  * @extends Dispatcher
  * @example
  * import {application} from 'nxus-core'
- * 
+ *
  * application.start()
  *
  * export default application
  *
- * 
+ *
  */
 
 
@@ -86,7 +84,7 @@ export default class Application extends Dispatcher {
     this._banner = opts.banner || startupBanner
     this._userConfig = {}
     this.config = {}
-    
+
     this._bootEvents = [
       'init',
       'load',
@@ -108,7 +106,7 @@ export default class Application extends Dispatcher {
   }
 
   _showBanner() {
-      console.log(" \n"+this._banner)
+    console.log(" \n"+this._banner)
   }
 
   /**
@@ -116,9 +114,9 @@ export default class Application extends Dispatcher {
    *
    * @private
    */
-  _setupConfig() {    
+  _setupConfig() {
     this.setUserConfig(null, _userConfig)
-        
+
     this.config = Object.assign(this.config, _defaultConfig)
     this.config = Object.assign(this.config, new ConfigurationManager(this.config).getConfig())
     this.config = Object.assign(this.config, this._opts)
@@ -127,7 +125,7 @@ export default class Application extends Dispatcher {
 
   /**
    * Sets up the internal log object. Falls back to console.log.
-   * 
+   *
    * @private
    */
   _setupLog() {
@@ -146,7 +144,7 @@ export default class Application extends Dispatcher {
 
   /**
    * Loads the internal _modules object by instantiating the PluginManager class.
-   * 
+   *
    * @private
    */
   _setupPluginManager() {
@@ -158,7 +156,7 @@ export default class Application extends Dispatcher {
 
   /**
    * Returns an internal ModuleProxy object for the given name.
-   * 
+   *
    * @param  {string} name The name of the module to return
    * @return {ModuleProxy}
    */
@@ -174,7 +172,7 @@ export default class Application extends Dispatcher {
    * Initializes the application by loading plugins, then booting the application.
    *
    * **Note**: this should rarely be called directly. Instead use #start
-   * 
+   *
    * @return {Promise}
    */
   _init() {
@@ -192,7 +190,7 @@ export default class Application extends Dispatcher {
    * Boots the application, cycling through the internal boot stages.
    *
    * **Note**: Should rarely be called directly. Instead use #start
-   * 
+   *
    * @return {Promise}
    */
   _boot() {
@@ -206,7 +204,7 @@ export default class Application extends Dispatcher {
 
   /**
    * Stops the currently running application
-   * 
+   *
    * @return {Promise}
    */
   stop() {
@@ -216,7 +214,7 @@ export default class Application extends Dispatcher {
 
   /**
    * Starts the Nxus application.
-   * 
+   *
    * @return {Promise}
    */
   start() {
@@ -227,7 +225,7 @@ export default class Application extends Dispatcher {
 
   /**
    * Restarts the Nxus application.
-   * 
+   *
    * @return {Promise}
    */
   restart() {
@@ -268,7 +266,7 @@ export default class Application extends Dispatcher {
 
   /**
    * Invalidates the internal require plugin cache, ensuring all plugins are reloaded from the files. Only applies to local app modules, not dependencies in node_modules.
-   * 
+   *
    * @private
    * @return {Promise}
    */
@@ -293,7 +291,7 @@ export default class Application extends Dispatcher {
   }
 
   /**
-   * Returns an array of watch paths, either as defined by `config.watch` or the default paths 
+   * Returns an array of watch paths, either as defined by `config.watch` or the default paths
    * `/node_modules` and `/modules`
    *
    * @private
@@ -337,7 +335,7 @@ export default class Application extends Dispatcher {
 
   /**
    * Iterates through all loaded plugins, instantiating them and returning a promise once every plugin has successfully started.
-   * 
+   *
    * @private
    * @return {Promise}
    */

--- a/src/Dispatcher.js
+++ b/src/Dispatcher.js
@@ -1,4 +1,4 @@
-/* 
+/*
 * @Author: Mike Reich
 * @Date:   2015-11-06 07:44:02
 * @Last Modified 2016-08-22
@@ -6,12 +6,13 @@
 
 'use strict';
 
+import Promise from 'bluebird'
 import { EventEmitter } from 'events'
 import _ from 'underscore'
 
 /**
- * The core Dispatcher class, which implements promisified 
- * 
+ * The core Dispatcher class, which implements promisified
+ *
  * @extends EventEmitter
  * @example
  * import { Dispatcher } from 'nxus-core'
@@ -25,15 +26,14 @@ export default class Dispatcher extends EventEmitter {
     super()
     this.setMaxListeners(1000)
   }
-  
+
   /**
    * Bind to an event once
-   * @param  {string} event The name of the event to bind to 
+   * @param  {string} event The name of the event to bind to
    * @param  {callable} [listener] The handler for the event
    * @return {Promise}       Returns a promise that resolves when the event fires
    */
   once (event, listener) {
-    let superOnce = super.once
     if (listener === undefined) {
       listener = () => {};
     }
@@ -43,7 +43,6 @@ export default class Dispatcher extends EventEmitter {
 
       var g = (...args) => {
         this.removeListener(event, g);
-        
         if (!fired) {
           fired = true;
           var result = listener.apply(this, args);
@@ -57,9 +56,9 @@ export default class Dispatcher extends EventEmitter {
   }
 
   /**
-   * Bind to before an event. Receives the event arguments, should return 
+   * Bind to before an event. Receives the event arguments, should return
    *  modified arguments or nothing.
-   * @param  {string} event The name of the event to bind to 
+   * @param  {string} event The name of the event to bind to
    * @param  {callable} listener The before handler for the event
    */
   before (event, listener) {
@@ -67,9 +66,9 @@ export default class Dispatcher extends EventEmitter {
   }
 
   /**
-   * Bind to after an event. Receives the event handlers results, should return 
+   * Bind to after an event. Receives the event handlers results, should return
    *  modified results or nothing.
-   * @param  {string} event The name of the event to bind to 
+   * @param  {string} event The name of the event to bind to
    * @param  {callable} listener The after handler for the event
    */
   after (event, listener) {
@@ -77,9 +76,9 @@ export default class Dispatcher extends EventEmitter {
   }
 
   /**
-   * Bind once to before an event. Receives the event arguments, should return 
+   * Bind once to before an event. Receives the event arguments, should return
    *  modified arguments or nothing.
-   * @param  {string} event The name of the event to bind to 
+   * @param  {string} event The name of the event to bind to
    * @param  {callable} listener The before handler for the event
    * @return {Promise}       Returns a promise that resolves when the event fires
    */
@@ -88,16 +87,16 @@ export default class Dispatcher extends EventEmitter {
   }
 
   /**
-   * Bind once to after an event. Receives the event handlers results, should return 
+   * Bind once to after an event. Receives the event handlers results, should return
    *  modified results or nothing.
-   * @param  {string} event The name of the event to bind to 
+   * @param  {string} event The name of the event to bind to
    * @param  {callable} listener The after handler for the event
    * @return {Promise}       Returns a promise that resolves when the event fires
    */
   onceAfter (event, listener) {
     return this.once(event+".after", listener);
   }
-  
+
   /**
    * Emits an event, calling all registered handlers.
    * @param  {string} event The name of the event to emit.
@@ -111,7 +110,7 @@ export default class Dispatcher extends EventEmitter {
         // Need to resolve internally so that we can allow observing-only handlers
         //  that don't return anything, even from their promise.
         return Promise.resolve(curr(prev, newArgs)).then((_args) => { return _args || prev });
-      }      
+      }
     }
 
     return Promise.reduce(super.listeners(event+".before"), waterfaller(), args)
@@ -151,4 +150,4 @@ export default class Dispatcher extends EventEmitter {
     }
     return results
   }
-} 
+}


### PR DESCRIPTION
I think these changes are all totally routine. However, I added a bunch of excludes to .npmignore, so you might take a look at what ends up in the npm package (package.json, README.md, LICENSE.md, bin/start.js, and lib/*.js). I think everything else was superfluous.

My plan, if I don't hear any objections in the next couple days, is to merge these changes, and also bump the version to 4.0.0.

More details:

In package.json, changed compile script to first do a `rm -r lib`, to clear out any obsoleted files; added `--ignore src/test` to babel, so test files aren't compiled.

In Application.js and Dispatcher.js, imported bluebird (needed for `Promise.map()`).