### PR TITLE
Fix to module loading error handling.

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "chokidar": "^1.6.0",
     "debug-logger": "^0.4.1",
     "deep-extend": "^0.4.1",
-    "findup-sync": "^0.4.2",
     "merge-descriptors": "^1.0.1",
     "moment": "^2.14.1",
     "morph": "^0.2.0",

--- a/src/PluginManager.js
+++ b/src/PluginManager.js
@@ -5,9 +5,8 @@
 * @Last Modified time: 2016-09-06 17:13:42
 */
 
-'use strict';
+'use strict'
 
-import findup from 'findup-sync'
 import multimatch from 'multimatch'
 import fs from 'fs'
 import path from 'path'
@@ -76,7 +75,14 @@ class PluginManager {
     })
   }
 
-  /**
+  /** Loads all modules from directory.
+   *
+   * A missing module produces a warning message. Other errors produce
+   * an error message and force the process to exit. (If `require()`
+   * reports a subsidiary module as missing, it forces an exit; that is,
+   * a missing nxus module is non-fatal, but a nxus module that is
+   * missing a required module is fatal.)
+   *
    * @private
    * [_loadModulesFromDirectory description]
    * @param  {[type]} dir     [description]
@@ -103,9 +109,11 @@ class PluginManager {
         //if(fs.existsSync(dir + "/" + name + "/node_modules")) 
           //this._loadModulesFromDirectory(dir + "/" + name + "/node_modules", matches)
       } catch (e) {
-        this.app.log.warn('Error loading module', name, modulePath)
-        if (e.code !== 'MODULE_NOT_FOUND') {
-          this.app.log.error(e)
+        // kludgy message text match to distinguish subsidiary modules from primary
+        if ((e.code === 'MODULE_NOT_FOUND') && e.message.includes(`'${modulePath}'`))
+          this.app.log.warn(`Module ${name} not found (${modulePath})`)
+        else {
+          this.app.log.error(`Error loading module ${name} (${modulePath})`, e)
           process.kill(process.pid, 'SIGTERM')
         }
       }


### PR DESCRIPTION
In `PluginManager#_loadModulesFromDirectory()`, a missing module is supposed to produce a warning message, but other errors are supposed to produce an error message and force the process to exit. However, if a module requires a subsidiary module that is missing, this too just generates a warning, when it should really be an error.

Changed the code to distinguish the different cases, and tweaked the messages. The test is a kludge, but I couldn't come up with anything better.