### PR TITLE
Fix issue with node event listeners change

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nxus-core",
   "main": "lib",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "A framework for building light-weight, event-driven data processing apps.",
   "bin": {
     "gonxus": "./bin/start.js"

--- a/src/Dispatcher.js
+++ b/src/Dispatcher.js
@@ -50,7 +50,6 @@ export default class Dispatcher extends EventEmitter {
           return result;
         }
       }
-      g.listener = listener;
       this.on.apply(this, [event, g]);
     })
   }


### PR DESCRIPTION
our Promise implementation of  should never be unwrapped. See https://github.com/nodejs/node/pull/6881 which was a breaking change for v6 to v7.

This has the potential to break uses of `removeListener` for `once` handlers. This does not appear to be a pattern used anywhere in the nxus/* modules at this time.