### PR TITLE
Added documentation and tests for Application start() method behavior.

### DIFF
--- a/src/Application.js
+++ b/src/Application.js
@@ -225,7 +225,7 @@ export default class Application extends Dispatcher {
    * Starts the Nxus application.
    *
    * @param {object} opts Config to deeply merge with default and rc configs
-   * @return {Promise}
+   * @return {Promise} resolves when the boot sequence is complete
    */
   start(opts={}) {
     if(!this.config.silent) this._showBanner()
@@ -237,7 +237,7 @@ export default class Application extends Dispatcher {
   /**
    * Restarts the Nxus application.
    *
-   * @return {Promise}
+   * @return {Promise} resolves when the restart boot sequence is complete
    */
   restart() {
     this._currentStage = 'restarting'

--- a/test/lib/Application.js
+++ b/test/lib/Application.js
@@ -234,6 +234,15 @@ describe("Application", () => {
       app.once('launch').then(done)
       app.start()
     })
+
+    it("start() should return a promise that resolves when boot sequence completes", (done) => {
+      let completed = false
+      app.onceAfter('launch').then(() => { completed = true })
+      app.start().then(() => {
+        completed.should.be.true()
+        done()
+      })
+    })
   })
 
   describe("Get Module", () => {


### PR DESCRIPTION
The promise returned by the `Application` `start()` method resolves when the application boot sequence completes (`restart()` behaves the same way).

This came up in writing test cases that needed to wait for the application to boot. Synchronizing with `start()` is quite a bit simpler/cleaner than using a `onceAfter('launch')` event handler. Don't know if it's useful anywhere else.