### PR TITLE
Dispatcher: don't squash single listener value '0' to undefined

### DIFF
--- a/src/Dispatcher.js
+++ b/src/Dispatcher.js
@@ -143,7 +143,7 @@ export default class Dispatcher extends EventEmitter {
 
   _squashMultipleListenerArrayResults(results) {
     if(_.isArray(results)) {
-      results = _.compact(results)
+      results = results.filter(x => x !== undefined)
       if(results.length < 1) return undefined
       else if (results.length == 1) return results[0]
     }

--- a/test/lib/Dispatcher.js
+++ b/test/lib/Dispatcher.js
@@ -56,6 +56,25 @@ describe("Dispatcher", () => {
         result.should.equal(1)
       })
     })
+
+    it("should return a value for single listener even if 0", () => {
+      module.on('event', () => {
+        return 0
+      })
+      return module.emit('event').then((result) => {
+        result.should.equal(0)
+      })
+    })
+    it("should return a value for multiple listener even if 0 and undefined", () => {
+      module.on('event', () => {
+        return 0
+      })
+      module.on('event', () => {
+      })
+      return module.emit('event').then((result) => {
+        result.should.equal(0)
+      })
+    })
     
     it("should return an array for multiple listeners", () => {
       module.on('event', () => {


### PR DESCRIPTION
David reported that async method calls returning 0 would show up as undefined. Yep.