### PR TITLE
Use JSON5 parser with rc config for nxusrc

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "preversion": "npm test",
     "postversion": "npm run build-docs && git push && git push --tags",
-    "test": "npm run compile && NODE_ENV=test nxus_myconfig=test mocha --compilers js:babel-core/register -R spec test/lib/* --config=./test/testApp/.nxusrc",
+    "test": "npm run compile && NODE_ENV=test nxus_myconfig=test mocha --compilers js:babel-core/register -R spec test/lib/*",
     "compile": "rm -rf lib/; babel src --out-dir lib && babel test/support/ --out-dir lib/test/support/",
     "prepublish": "npm run compile",
     "postpublish": "npm run build-docs && npm run publish-docs",
@@ -40,6 +40,7 @@
     "chokidar": "^1.6.0",
     "debug-logger": "^0.4.1",
     "deep-extend": "^0.4.1",
+    "json5": "^2.1.1",
     "merge-descriptors": "^1.0.1",
     "moment": "^2.14.1",
     "morph": "^0.2.0",

--- a/src/ConfigurationManager.js
+++ b/src/ConfigurationManager.js
@@ -15,9 +15,9 @@ import json5 from 'json5'
 /**
  * @private
  * ConfigurationManager loads the internal app.config hash using the following order (each overwrites any values of the previous):
- * 1. Opts loaded into the application object.
- * 2. Opts in the `config` hash of the project package.json file
- * 3. Any environment variables
+ * 1. From opts `config` file path (can be JSON or JSON5) and from opts `namespace` '.{namespace}rc` file.
+ * 2. Any environment variables, both as-is and parsed from `{namespace}_obj__key` names.
+ *
  */
 class ConfigurationManager {
 

--- a/src/ConfigurationManager.js
+++ b/src/ConfigurationManager.js
@@ -11,7 +11,7 @@ import fs from 'fs'
 import _ from 'underscore'
 import path from 'path'
 import rc from 'rc'
-
+import json5 from 'json5'
 /**
  * @private
  * ConfigurationManager loads the internal app.config hash using the following order (each overwrites any values of the previous):
@@ -39,7 +39,7 @@ class ConfigurationManager {
    * @return {object} the intenral `config` object or an empty object if it isn't defined.
    */
   _rcConfig() {
-    return rc(this.opts.namespace, {})
+    return rc(this.opts.namespace, {}, {config: this.opts.config}, json5.parse)
   }
 
   /**

--- a/test/lib/ConfigurationManager.js
+++ b/test/lib/ConfigurationManager.js
@@ -33,10 +33,23 @@ describe("ConfigurationManager", () => {
       done()
     })
   })
+
+  describe("Package Config as JSON5", () => {
+    before((done) => {
+      instance = new ConfigurationManager({config: __dirname+"/../testApp5/.nxusrc", env: 'test', namespace: 'nxus'})
+      done()
+    })
+    it("should read rc config", (done) => {
+      let config = instance.getConfig()
+      config.should.have.property('siteName', 'test-nxus-app-json5')
+      config.should.have.property('customConfig', 'default')
+      done()
+    })
+  })
   
   describe("Package Config", () => {
     before((done) => {
-      instance = new ConfigurationManager({appDir: __dirname+"/../testApp", env: 'test', namespace: 'nxus'})
+      instance = new ConfigurationManager({config: __dirname+"/../testApp/.nxusrc", env: 'test', namespace: 'nxus'})
       done()
     })
     it("should read rc config", (done) => {

--- a/test/testApp5/.nxusrc
+++ b/test/testApp5/.nxusrc
@@ -1,0 +1,10 @@
+{
+  // Comments are ok
+  // as are unquoted keys and single-quotes
+  siteName: 'test-nxus-app-json5',
+  "customConfig": "default",
+  "host": "localhost",
+  "baseUrl": "localhost:3001",
+  "appName": "App",
+  "namespace": "nxus", // trailing commas are ok
+}


### PR DESCRIPTION
1. FYI, discovered that `rc` by default allows comments in rc json (strips before parsing) so our main goal can already be met without this PR
2. `rc` accepts a parser argument, so at the 'cost' of only supporting json/json5 (not `ini`) configs this is a simple change (if someone knows why we should continue to support `ini`, speak now, I don't think we've ever done that.
3. Changed ConfigurationManager to pass in the config file explicitly, turns out rc does a bunch of guessing based on `cwd` to find the rc file and the tests had previously been relying on `--config .....` in the `npm test` line to force the `testApp` file. `Application` sets the config key already based on `cwd`, so now the tests do too.