### PR TITLE
Support nested modules with namespaced plugin/proxy/log names

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/nxus/core",
   "engines": {
-    "node": "~6"
+    "node": "~6,~8,~10~,~12"
   },
   "dependencies": {
     "async": "^2.0.1",

--- a/src/Application.js
+++ b/src/Application.js
@@ -367,17 +367,19 @@ export default class Application extends Dispatcher {
    * @return {[type]}
    */
   _bootPlugin(plugin) {
-    var name = plugin._pluginInfo.name
-    let path = plugin._pluginInfo.modulePath
+    let pluginInfo = plugin._pluginInfo
+
+    if(plugin.default)
+      plugin = plugin.default
+
+    let name = (plugin._moduleName && plugin._moduleName()) || pluginInfo.name
     let pluginInstance = null
     let promise = null
-    //if (this.config.debug) console.log(' ------- ', plugin)
+
     if (this._pluginInstances[name] !== undefined) {
       this.log.error('Duplicate module found', name)
       process.exit()
     }
-    if(plugin.default)
-      plugin = plugin.default
 
     if(plugin.__appRef && plugin.__appRef() !== this) {
       this.log.error('Separate Nxus Core module detected in', name)
@@ -393,7 +395,7 @@ export default class Application extends Dispatcher {
         this._pluginInstances[name] = pluginInstance
         promise = Promise.resolve(pluginInstance)
       } catch(e) {
-        this.log.error('Error booting module '+name+' from '+path, e)
+        this.log.error('Error booting module '+name+' from '+pluginInfo.modulePath, e)
         this.log.error(e.stack)
         process.exit()
       }

--- a/src/NxusModule.js
+++ b/src/NxusModule.js
@@ -55,7 +55,7 @@ class NxusModule {
   constructor(app) {
     this._dirName = path.dirname(_filenameOf(this.constructor))
     this.__name = this.constructor._moduleName()
-    this.__config_name = this.constructor._configName(this.__name)
+    this.__config_name = this.constructor._configName()
     this.log = Logger(this.__name)
 
     let userConfig = this._userConfig()
@@ -94,8 +94,8 @@ class NxusModule {
     return application
   }
 
-  static _configName(name) {
-    return morph.toSnake(name)
+  static _configName() {
+    return morph.toSnake(this._moduleName())
   }
 
   static _moduleName(filename) {

--- a/src/NxusModule.js
+++ b/src/NxusModule.js
@@ -1,17 +1,47 @@
 import morph from 'morph'
 import path from 'path'
+import fs from 'fs'
 import stackTrace from 'stack-trace'
 import ModuleProxy from './ModuleProxy'
 import {application} from './Application'
 import Logger from './Logger'
 import deepExtend from 'deep-extend'
 
-function __dirName(constructorName) {
-  for (let site of stackTrace.get()) {
-    if(site.getFunctionName() == constructorName) {
-      return path.dirname(site.getFileName())
+function _filenameOf(construct) {
+  for (let [k,v] of Object.entries(require.cache)) {
+    let exports = v.exports.default ? v.exports : {default: v.exports}
+    for (let [,ex] of Object.entries(exports)) {
+      if (ex == construct) {
+        return v.filename
+      }
     }
   }
+  for (let site of stackTrace.get()) {
+    if(site.getFunctionName() == construct.name) {
+      return site.getFileName()
+    }
+  }
+}
+
+const EXCLUDE_DIRNAMES = ['src', 'lib', 'test', 'modules']
+
+function _modulePrefix(filename) {
+  let dirname = path.dirname(filename)
+  let dirs = dirname.split(path.sep)
+  let result = []
+  let root
+  while (!root && dirs.length) {
+    let testFile = dirs.concat(['package.json']).join(path.sep)
+    if (fs.existsSync(testFile)) {
+      root = true
+    } else {
+      let p = dirs.pop()
+      if (!EXCLUDE_DIRNAMES.includes(p)) {
+        result.unshift(p)
+      }
+    }
+  }
+  return result.join('/')
 }
 
 /**
@@ -23,8 +53,9 @@ function __dirName(constructorName) {
 class NxusModule {
 
   constructor(app) {
+    this._dirName = path.dirname(_filenameOf(this.constructor))
     this.__name = this.constructor._moduleName()
-    this.__config_name = this.constructor._configName()
+    this.__config_name = this.constructor._configName(this.__name)
     this.log = Logger(this.__name)
 
     let userConfig = this._userConfig()
@@ -32,15 +63,18 @@ class NxusModule {
       application.setUserConfig(this.__config_name, userConfig)
     }
 
-    this._dirName = __dirName(this.constructor.name)
-
     this.__proxy = application.get(this.__name)
     this.__proxy.use(this)
   }
 
   get config() {
     let _defaultConfig = this._defaultConfig() || {}
-    if(!this._config) this._config = Object.assign({}, deepExtend(_defaultConfig, application.config[this.__config_name]))
+    if (!this._config) {
+      this._config = Object.assign(
+        {},
+        deepExtend(_defaultConfig, application.config[this.__config_name])
+      )
+    }
     return this._config
   }
 
@@ -60,16 +94,27 @@ class NxusModule {
     return application
   }
 
-  static _configName() {
-    return morph.toSnake(this.name)
+  static _configName(name) {
+    return morph.toSnake(name)
   }
 
-  static _moduleName() {
-    return morph.toDashed(this.name)
+  static _moduleName(filename) {
+    if (filename === undefined) {
+      filename = _filenameOf(this)
+    }
+    let useMyName = path.basename(filename) != 'index.js'
+    let name = _modulePrefix(filename)
+    // this logic of ignoring class name for modules
+    // is in part to match src/PluginManager:_loadModulesFromDirectory
+    if (useMyName) {
+      name = name ? name + "/" + this.name : this.name
+    }
+    return morph.toDashed(name)
   }
 
   static getProxy() {
-    return application.get(this._moduleName())
+    // force to caller file, assuming getProxy is called in same file as class definition
+    return application.get(this._moduleName(stackTrace.get()[1].getFileName()))
   }
 
   deregister() {

--- a/src/NxusModule.js
+++ b/src/NxusModule.js
@@ -9,7 +9,7 @@ import deepExtend from 'deep-extend'
 
 function _filenameOf(construct) {
   for (let [k,v] of Object.entries(require.cache)) {
-    let exports = v.exports.default ? v.exports : {default: v.exports}
+    let exports = v.exports && v.exports.default ? v.exports : {default: v.exports}
     for (let [,ex] of Object.entries(exports)) {
       if (ex == construct) {
         return v.filename
@@ -28,6 +28,7 @@ const EXCLUDE_DIRNAMES = ['src', 'lib', 'test', 'modules']
 function _modulePrefix(filename) {
   let dirname = path.dirname(filename)
   let dirs = dirname.split(path.sep)
+  let isIndex = path.basename(filename) == 'index.js'
   let result = []
   let root
   while (!root && dirs.length) {
@@ -40,6 +41,9 @@ function _modulePrefix(filename) {
         result.unshift(p)
       }
     }
+  }
+  if (isIndex) {
+    result.pop()
   }
   return result.join('/')
 }
@@ -102,13 +106,10 @@ class NxusModule {
     if (filename === undefined) {
       filename = _filenameOf(this)
     }
-    let useMyName = path.basename(filename) != 'index.js'
-    let name = _modulePrefix(filename)
+    let prefix = _modulePrefix(filename)
     // this logic of ignoring class name for modules
     // is in part to match src/PluginManager:_loadModulesFromDirectory
-    if (useMyName) {
-      name = name ? name + "/" + this.name : this.name
-    }
+    let name = prefix ? prefix + "/" + this.name : this.name
     return morph.toDashed(name)
   }
 

--- a/src/PluginManager.js
+++ b/src/PluginManager.js
@@ -90,6 +90,7 @@ class PluginManager {
    * @return {[type]}         [description]
    */
   _loadModulesFromDirectory(dir, isLocal, matches, prefix='') {
+    
     if (!fs.existsSync(dir)) return
 
     var moduleDirs = fs.readdirSync(dir)
@@ -107,8 +108,8 @@ class PluginManager {
         // this module prefix naming matches src/NxusModule:_moduleName we hope
         let newPrefix = modName+"/"
         // Recurse for module modules
-        this._loadModulesFromDirectory(path.join(dir, name, 'modules'), isLocal, newPrefix)
-        this._loadModulesFromDirectory(path.join(dir, name, 'lib', 'modules'), isLocal, newPrefix)
+        this._loadModulesFromDirectory(path.join(dir, name, 'modules'), isLocal, null, newPrefix)
+        this._loadModulesFromDirectory(path.join(dir, name, 'lib', 'modules'), isLocal, null, newPrefix)
       } catch (e) {
         // kludgy message text match to distinguish subsidiary modules from primary
         if ((e.code === 'MODULE_NOT_FOUND') && e.message.includes(`'${modulePath}'`))

--- a/test/lib/NxusModule.js
+++ b/test/lib/NxusModule.js
@@ -8,6 +8,9 @@
 
 import {NxusModule, application} from '../../lib/'
 
+import OneModule from './modules/one'
+import NestedSub from './modules/one/modules/sub'
+
 class SubModule extends NxusModule {
 
   _defaultConfig() {
@@ -40,6 +43,8 @@ describe("NxusModule", () => {
 
     it("should set itself in app modules with the config name (dashed)", () => {
       application._moduleProxies.should.have.property('sub-module')
+      // NestedSub
+      application._moduleProxies.should.have.property('one/sub')
     })
 
     it("should set defaultConfig", () => {
@@ -75,6 +80,25 @@ describe("NxusModule", () => {
   describe("_dirName", () => {
     it("should be this directory", () => {
       instance._dirName.includes("test/lib").should.equal(true)
+    })
+  })
+
+  describe("_moduleName", () => {
+    it("should be the module name dashed", () => {
+      // SubModule isn't exported so not available 
+      //SubModule._moduleName().should.equal('sub-module')
+      instance.__name.should.equal('sub-module')
+    })
+    it("should use dir name for index module", () => {
+      OneModule._moduleName().should.equal('one')
+    })
+    it("should include nested directories and use dir name for index", () => {
+      NestedSub._moduleName().should.equal('one/sub')
+    })
+    it("should include nested directories for arbitrary internal modules", () => {
+      let n = new NestedSub()
+      n.controller.__name.should.equal('one/sub/controllers/nested-controller')
+      application._moduleProxies.should.have.property('one/sub/controllers/nested-controller')
     })
   })
 

--- a/test/lib/NxusModule.js
+++ b/test/lib/NxusModule.js
@@ -44,7 +44,7 @@ describe("NxusModule", () => {
     it("should set itself in app modules with the config name (dashed)", () => {
       application._moduleProxies.should.have.property('sub-module')
       // NestedSub
-      application._moduleProxies.should.have.property('one/sub')
+      application._moduleProxies.should.have.property('one/nested-sub')
     })
 
     it("should set defaultConfig", () => {
@@ -89,11 +89,11 @@ describe("NxusModule", () => {
       //SubModule._moduleName().should.equal('sub-module')
       instance.__name.should.equal('sub-module')
     })
-    it("should use dir name for index module", () => {
+    it("should not duplicate module name when index module", () => {
       OneModule._moduleName().should.equal('one')
     })
-    it("should include nested directories and use dir name for index", () => {
-      NestedSub._moduleName().should.equal('one/sub')
+    it("should include nested directories and use module class name", () => {
+      NestedSub._moduleName().should.equal('one/nested-sub')
     })
     it("should include nested directories for arbitrary internal modules", () => {
       let n = new NestedSub()

--- a/test/lib/modules/one/index.js
+++ b/test/lib/modules/one/index.js
@@ -1,5 +1,5 @@
 import {NxusModule} from '../../../../lib'
 
-export default class OneModule extends NxusModule {
+export default class One extends NxusModule {
   
 }

--- a/test/lib/modules/one/index.js
+++ b/test/lib/modules/one/index.js
@@ -1,0 +1,5 @@
+import {NxusModule} from '../../../../lib'
+
+export default class OneModule extends NxusModule {
+  
+}

--- a/test/lib/modules/one/modules/sub/controllers/nested.js
+++ b/test/lib/modules/one/modules/sub/controllers/nested.js
@@ -1,0 +1,5 @@
+import {NxusModule} from '../../../../../../../lib'
+
+export default class NestedController extends NxusModule {
+  
+}

--- a/test/lib/modules/one/modules/sub/index.js
+++ b/test/lib/modules/one/modules/sub/index.js
@@ -1,0 +1,14 @@
+import {NxusModule} from '../../../../../../lib'
+
+import NestedController from './controllers/nested'
+
+class NestedSub extends NxusModule {
+  constructor() {
+    super()
+    this.controller = new NestedController()
+  }
+  
+}
+
+let nestedSub = NestedSub.getProxy()
+export {NestedSub as default, nestedSub}


### PR DESCRIPTION
Resolves #127 and keeps all the hacks hidden away in NxusModule still?

Note that there are many different paths for determining the directory path prefix:
 - When constructing a module instance that has been exported/required somewhere
   - uses require.cache so that static methods can also find this
 - When constructing a module instance that is internal and never exported (happens in test, could happen elsewhere but probably doesn't today, but hard to ban)
   - uses old stacktrace-based approach since we are calling from constructor
 - When calling `getProxy` in a module file before it is exported.
   - use the caller file under the assumption `getProxy` is only called next to module class definition
 - When finding modules to import recursively in `PluginManager`
   - attempt to match `_moduleName` logic in effect for "Loading" message, but if using a module that has `_moduleName` this will be favored by the time the Application proxies etc.